### PR TITLE
Redesign portfolio with dark terminal aesthetic and theme toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,16 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="dark">
 <head>
+  <script>
+    (function(){
+      var s = localStorage.getItem('theme') || 'system';
+      var t = s === 'system'
+        ? (window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark')
+        : s;
+      document.documentElement.setAttribute('data-theme', t);
+      document.documentElement.setAttribute('data-theme-pref', s);
+    })();
+  </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Yash · Backend Engineer</title>
@@ -26,6 +36,22 @@
       --dim:          #94a3b8;
       --mono:         'JetBrains Mono', monospace;
       --sans:         'Syne', sans-serif;
+      --nav-bg:       rgba(6,6,15,0.75);
+    }
+
+    [data-theme="light"] {
+      --bg:        #f5f4ef;
+      --bg-card:   #ffffff;
+      --bg-card-h: #faf9f5;
+      --border:    rgba(0,0,0,0.09);
+      --border-h:  rgba(245,158,11,0.35);
+      --text:      #0f0f1a;
+      --muted:     #6b7280;
+      --dim:       #374151;
+      --nav-bg:    rgba(245,244,239,0.82);
+      --amber-glow: rgba(245,158,11,0.10);
+      --blue-dim:  rgba(14,120,180,0.10);
+      --blue:      #0b6fa8;
     }
 
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -38,6 +64,7 @@
       line-height: 1.6;
       overflow-x: hidden;
       -webkit-font-smoothing: antialiased;
+      transition: background 0.3s, color 0.3s;
     }
 
     ::-webkit-scrollbar { width: 3px; }
@@ -53,8 +80,9 @@
       display: flex;
       justify-content: space-between;
       align-items: center;
-      background: rgba(6,6,15,0.75);
+      background: var(--nav-bg);
       backdrop-filter: blur(20px);
+      transition: background 0.3s;
       border-bottom: 1px solid var(--border);
     }
 
@@ -554,6 +582,36 @@
     }
     .reveal.vis { opacity:1; transform:none; }
 
+    /* ── THEME TOGGLE ────────────────────────────────────────────── */
+    .theme-toggle {
+      display: flex;
+      border: 1px solid var(--border);
+      border-radius: 3px;
+      overflow: hidden;
+      flex-shrink: 0;
+      transition: border-color 0.3s;
+    }
+    .tt-btn {
+      background: none;
+      border: none;
+      border-right: 1px solid var(--border);
+      padding: 0.3rem 0.6rem;
+      cursor: pointer;
+      font-size: 0.75rem;
+      color: var(--muted);
+      transition: background 0.15s, color 0.15s, border-color 0.3s;
+      line-height: 1;
+      display: flex;
+      align-items: center;
+    }
+    .tt-btn:last-child { border-right: none; }
+    .tt-btn svg { pointer-events: none; }
+    .tt-btn:hover { color: var(--amber); }
+    .tt-btn.active {
+      background: var(--amber-glow);
+      color: var(--amber);
+    }
+
     /* ── RESPONSIVE ──────────────────────────────────────────────── */
     @media (max-width: 720px) {
       nav { padding: 1rem 1.5rem; }
@@ -581,6 +639,17 @@
     <li><a href="#journey">Journey</a></li>
     <li><a href="https://github.com/stupidly-logical" target="_blank" rel="noopener">GitHub&nbsp;↗</a></li>
   </ul>
+  <div class="theme-toggle" id="theme-toggle" role="group" aria-label="Color theme">
+    <button class="tt-btn" data-t="dark"   title="Dark mode">
+      <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+    </button>
+    <button class="tt-btn" data-t="system" title="System default">
+      <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg>
+    </button>
+    <button class="tt-btn" data-t="light"  title="Light mode">
+      <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
+    </button>
+  </div>
 </nav>
 
 <!-- ── HERO ──────────────────────────────────────────────────────── -->
@@ -949,6 +1018,40 @@
   stagger('.skill-group', '--sd', 0.09);
   stagger('.proj-card',   '--pd', 0.07);
   stagger('.tl-item',     '--td', 0.1);
+})();
+
+// ── THEME ──────────────────────────────────────────────────────────
+(function () {
+  const html    = document.documentElement;
+  const toggle  = document.getElementById('theme-toggle');
+  const mq      = window.matchMedia('(prefers-color-scheme: light)');
+
+  function applyTheme(pref) {
+    const resolved = pref === 'system' ? (mq.matches ? 'light' : 'dark') : pref;
+    html.setAttribute('data-theme', resolved);
+    html.setAttribute('data-theme-pref', pref);
+    toggle.querySelectorAll('.tt-btn').forEach(b => {
+      b.classList.toggle('active', b.dataset.t === pref);
+    });
+  }
+
+  // init from stored pref
+  const stored = localStorage.getItem('theme') || 'system';
+  applyTheme(stored);
+
+  // button clicks
+  toggle.querySelectorAll('.tt-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const pref = btn.dataset.t;
+      localStorage.setItem('theme', pref);
+      applyTheme(pref);
+    });
+  });
+
+  // react to OS change when in system mode
+  mq.addEventListener('change', () => {
+    if ((localStorage.getItem('theme') || 'system') === 'system') applyTheme('system');
+  });
 })();
 </script>
 </body>

--- a/index.html
+++ b/index.html
@@ -1,219 +1,955 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
 <head>
-    <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-144772663-2"></script>
-    <script>
-        window.dataLayer = window.dataLayer || [];
-        function gtag(){dataLayer.push(arguments);}
-        gtag('js', new Date());
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Yash · Backend Engineer</title>
+  <meta name="description" content="Backend engineer specializing in distributed systems, event-driven architecture, and Java/Spring Boot. Based in India.">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,300;0,400;0,500;0,700;1,300&family=Syne:wght@400;600;700;800&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --bg:           #06060f;
+      --bg-card:      #0b0b18;
+      --bg-card-h:    #0f0f1f;
+      --border:       rgba(255,255,255,0.055);
+      --border-h:     rgba(245,158,11,0.25);
+      --amber:        #f59e0b;
+      --amber-dim:    rgba(245,158,11,0.45);
+      --amber-glow:   rgba(245,158,11,0.12);
+      --blue:         #38bdf8;
+      --blue-dim:     rgba(56,189,248,0.12);
+      --green:        #34d399;
+      --text:         #e2e8f0;
+      --muted:        #64748b;
+      --dim:          #94a3b8;
+      --mono:         'JetBrains Mono', monospace;
+      --sans:         'Syne', sans-serif;
+    }
 
-        gtag('config', 'UA-144772663-2');
-    </script>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    html { scroll-behavior: smooth; }
 
-    <!-- Required meta tags -->
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    body {
+      background: var(--bg);
+      color: var(--text);
+      font-family: var(--mono);
+      line-height: 1.6;
+      overflow-x: hidden;
+      -webkit-font-smoothing: antialiased;
+    }
 
-    <!-- Google Fonts -->
-    <link href="https://fonts.googleapis.com/css?family=Roboto:400,700&display=swap" rel="stylesheet">
-    
-    <!-- Font Awesome -->
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+    ::-webkit-scrollbar { width: 3px; }
+    ::-webkit-scrollbar-track { background: var(--bg); }
+    ::-webkit-scrollbar-thumb { background: var(--amber-dim); border-radius: 2px; }
 
-    <!-- Bootstrap CSS -->
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
+    /* ── NAV ─────────────────────────────────────────────────────── */
+    nav {
+      position: fixed;
+      top: 0; left: 0; right: 0;
+      z-index: 200;
+      padding: 1.1rem 2.5rem;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      background: rgba(6,6,15,0.75);
+      backdrop-filter: blur(20px);
+      border-bottom: 1px solid var(--border);
+    }
 
-    <link rel="stylesheet" href="css/base.css">
+    .nav-logo {
+      font-size: 0.8rem;
+      letter-spacing: 0.04em;
+      color: var(--dim);
+    }
+    .nav-logo em { font-style: normal; color: var(--amber); }
 
-    <title>Yash Krishan Verma</title>
+    .nav-links { display: flex; gap: 2.5rem; list-style: none; }
+    .nav-links a {
+      color: var(--muted);
+      text-decoration: none;
+      font-size: 0.7rem;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      transition: color 0.2s;
+    }
+    .nav-links a:hover { color: var(--amber); }
+
+    /* ── HERO ─────────────────────────────────────────────────────── */
+    #hero {
+      position: relative;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      overflow: hidden;
+    }
+
+    #net-canvas {
+      position: absolute;
+      inset: 0;
+      width: 100%;
+      height: 100%;
+    }
+
+    /* CRT scanline overlay */
+    #hero::before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      z-index: 1;
+      background: repeating-linear-gradient(
+        0deg,
+        transparent,
+        transparent 2px,
+        rgba(0,0,0,0.03) 2px,
+        rgba(0,0,0,0.03) 4px
+      );
+      pointer-events: none;
+    }
+
+    /* bottom fade into page */
+    #hero::after {
+      content: '';
+      position: absolute;
+      bottom: 0; left: 0; right: 0;
+      height: 200px;
+      background: linear-gradient(transparent, var(--bg));
+      z-index: 2;
+      pointer-events: none;
+    }
+
+    .hero-inner {
+      position: relative;
+      z-index: 3;
+      width: 100%;
+      max-width: 1200px;
+      margin: 0 auto;
+      padding: 0 2.5rem;
+      padding-top: 5rem;
+      display: grid;
+      grid-template-columns: auto 1fr;
+      gap: 4rem;
+      align-items: center;
+    }
+
+    /* Avatar */
+    .avi-wrap {
+      position: relative;
+      width: 155px;
+      height: 155px;
+      flex-shrink: 0;
+    }
+
+    .avi-wrap::before {
+      content: '';
+      position: absolute;
+      inset: -4px;
+      border-radius: 50%;
+      background: conic-gradient(
+        from 0deg,
+        var(--amber) 0deg,
+        rgba(245,158,11,0.1) 120deg,
+        var(--amber) 240deg,
+        rgba(245,158,11,0.05) 300deg,
+        var(--amber) 360deg
+      );
+      animation: spin-ring 7s linear infinite;
+      z-index: 0;
+    }
+
+    @keyframes spin-ring { to { transform: rotate(360deg); } }
+
+    .avi-wrap img {
+      position: absolute;
+      inset: 4px;
+      width: calc(100% - 8px);
+      height: calc(100% - 8px);
+      border-radius: 50%;
+      object-fit: cover;
+      z-index: 2;
+      border: 2px solid var(--bg);
+    }
+
+    .avi-dot {
+      position: absolute;
+      bottom: 8px; right: 8px;
+      width: 16px; height: 16px;
+      background: var(--green);
+      border: 3px solid var(--bg);
+      border-radius: 50%;
+      z-index: 3;
+      animation: pulse-green 2s ease-in-out infinite;
+    }
+
+    @keyframes pulse-green {
+      0%, 100% { box-shadow: 0 0 0 0 rgba(52,211,153,0.5); }
+      50%       { box-shadow: 0 0 0 8px rgba(52,211,153,0); }
+    }
+
+    /* Hero text */
+    .hero-text {}
+
+    .hero-eyebrow {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      font-size: 0.68rem;
+      letter-spacing: 0.22em;
+      text-transform: uppercase;
+      color: var(--amber);
+      margin-bottom: 0.9rem;
+    }
+    .hero-eyebrow::before {
+      content: '';
+      display: inline-block;
+      width: 28px;
+      height: 1px;
+      background: var(--amber);
+    }
+
+    .hero-name {
+      font-family: var(--sans);
+      font-size: clamp(3.2rem, 9vw, 6rem);
+      font-weight: 800;
+      line-height: 0.9;
+      letter-spacing: -0.03em;
+      color: var(--text);
+      margin-bottom: 1.4rem;
+    }
+
+    .hero-tagline {
+      font-size: 0.95rem;
+      color: var(--dim);
+      font-weight: 300;
+      min-height: 1.5em;
+      margin-bottom: 2.2rem;
+      font-style: italic;
+    }
+
+    .cursor {
+      display: inline-block;
+      width: 2px;
+      height: 0.9em;
+      background: var(--amber);
+      margin-left: 1px;
+      vertical-align: middle;
+      animation: blink 1s step-end infinite;
+    }
+    @keyframes blink { 0%,100% { opacity:1 } 50% { opacity:0 } }
+
+    .hero-chips {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.65rem;
+    }
+
+    .chip {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.4rem;
+      padding: 0.35rem 0.85rem;
+      border: 1px solid var(--border);
+      font-size: 0.68rem;
+      letter-spacing: 0.08em;
+      color: var(--muted);
+      background: rgba(255,255,255,0.02);
+      border-radius: 2px;
+      transition: border-color 0.2s, color 0.2s;
+    }
+    .chip.hire {
+      border-color: rgba(52,211,153,0.3);
+      color: var(--green);
+    }
+    .chip.hire::before {
+      content: '●';
+      font-size: 0.45rem;
+      animation: blink 2s step-end infinite;
+    }
+
+    .scroll-cue {
+      position: absolute;
+      bottom: 2rem;
+      left: 50%;
+      transform: translateX(-50%);
+      z-index: 3;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 6px;
+      color: var(--muted);
+      font-size: 0.6rem;
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
+      animation: bob 2.5s ease-in-out infinite;
+    }
+    .scroll-cue::after {
+      content: '';
+      width: 1px;
+      height: 36px;
+      background: linear-gradient(to bottom, var(--amber-dim), transparent);
+    }
+    @keyframes bob {
+      0%,100% { opacity: 0.35; transform: translateX(-50%) translateY(0); }
+      50%      { opacity: 0.8;  transform: translateX(-50%) translateY(8px); }
+    }
+
+    /* ── SECTIONS ─────────────────────────────────────────────────── */
+    .section {
+      max-width: 1200px;
+      margin: 0 auto;
+      padding: 7rem 2.5rem;
+    }
+
+    .s-eyebrow {
+      font-size: 0.65rem;
+      letter-spacing: 0.22em;
+      text-transform: uppercase;
+      color: var(--amber);
+      margin-bottom: 0.4rem;
+    }
+
+    .s-title {
+      font-family: var(--sans);
+      font-size: clamp(2rem, 5vw, 3.2rem);
+      font-weight: 700;
+      line-height: 1;
+      margin-bottom: 3.5rem;
+      letter-spacing: -0.02em;
+    }
+    .s-title span { color: var(--amber); }
+
+    /* ── SKILLS ──────────────────────────────────────────────────── */
+    .skills-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+      gap: 1.25rem;
+    }
+
+    .skill-group {
+      padding: 1.5rem;
+      background: var(--bg-card);
+      border: 1px solid var(--border);
+      border-top: 2px solid var(--amber);
+      opacity: 0;
+      transform: translateY(14px);
+      transition: opacity 0.45s ease, transform 0.45s ease, box-shadow 0.3s;
+      transition-delay: var(--sd, 0s);
+    }
+    .skill-group:hover {
+      box-shadow: 0 0 0 1px var(--border-h), 0 8px 30px var(--amber-glow);
+    }
+    .skill-group.vis { opacity:1; transform:none; }
+
+    .sg-name {
+      font-size: 0.6rem;
+      letter-spacing: 0.2em;
+      text-transform: uppercase;
+      color: var(--amber);
+      margin-bottom: 0.9rem;
+    }
+
+    .sg-tags { display: flex; flex-wrap: wrap; gap: 0.45rem; }
+
+    .tag {
+      padding: 0.28rem 0.6rem;
+      background: var(--amber-glow);
+      border: 1px solid rgba(245,158,11,0.12);
+      border-radius: 2px;
+      font-size: 0.7rem;
+      color: var(--dim);
+      transition: background 0.2s, border-color 0.2s, color 0.2s;
+      cursor: default;
+    }
+    .tag:hover {
+      background: rgba(245,158,11,0.18);
+      border-color: rgba(245,158,11,0.4);
+      color: var(--amber);
+    }
+
+    /* ── PROJECTS ────────────────────────────────────────────────── */
+    .projects-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(330px, 1fr));
+      gap: 1.25rem;
+    }
+
+    .proj-card {
+      display: block;
+      text-decoration: none;
+      color: inherit;
+      padding: 1.75rem;
+      background: var(--bg-card);
+      border: 1px solid var(--border);
+      border-left: 2px solid var(--amber-dim);
+      transition: transform 0.3s ease, box-shadow 0.3s ease, border-left-color 0.3s, background 0.3s;
+      opacity: 0;
+      transform: translateY(18px);
+      transition-delay: var(--pd, 0s);
+    }
+    .proj-card.vis {
+      opacity: 1;
+      transform: translateY(0);
+      transition: opacity 0.45s ease var(--pd, 0s), transform 0.45s ease var(--pd, 0s),
+                  border-left-color 0.3s, box-shadow 0.3s, background 0.3s, transform 0.3s;
+    }
+    .proj-card:hover {
+      background: var(--bg-card-h);
+      border-left-color: var(--amber);
+      transform: translateY(-5px);
+      box-shadow: 0 12px 40px rgba(245,158,11,0.07), 0 0 0 1px rgba(245,158,11,0.08);
+    }
+
+    .proj-meta {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      font-size: 0.62rem;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: var(--muted);
+      margin-bottom: 0.9rem;
+    }
+    .dot { width: 6px; height: 6px; border-radius: 50%; background: var(--green); }
+    .dot.old { background: var(--muted); }
+
+    .proj-name {
+      font-family: var(--sans);
+      font-size: 1.2rem;
+      font-weight: 700;
+      color: var(--text);
+      margin-bottom: 0.55rem;
+      line-height: 1.2;
+    }
+
+    .proj-desc {
+      font-size: 0.77rem;
+      color: var(--muted);
+      line-height: 1.75;
+      margin-bottom: 1.2rem;
+      font-weight: 300;
+    }
+
+    .proj-tags { display: flex; flex-wrap: wrap; gap: 0.4rem; margin-bottom: 1.2rem; }
+    .ptag {
+      padding: 0.18rem 0.5rem;
+      background: var(--blue-dim);
+      border: 1px solid rgba(56,189,248,0.14);
+      border-radius: 2px;
+      font-size: 0.62rem;
+      color: var(--blue);
+      letter-spacing: 0.04em;
+    }
+
+    .proj-cta {
+      font-size: 0.68rem;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      color: var(--amber);
+      display: flex;
+      align-items: center;
+      gap: 0.4rem;
+      transition: gap 0.2s;
+    }
+    .proj-card:hover .proj-cta { gap: 0.75rem; }
+
+    /* ── TIMELINE ────────────────────────────────────────────────── */
+    .timeline {
+      position: relative;
+      padding-left: 2.5rem;
+      max-width: 720px;
+    }
+    .timeline::before {
+      content: '';
+      position: absolute;
+      left: 0; top: 6px; bottom: 0;
+      width: 1px;
+      background: linear-gradient(to bottom, var(--amber) 0%, rgba(245,158,11,0.1) 80%, transparent 100%);
+    }
+
+    .tl-item {
+      position: relative;
+      padding-bottom: 2.75rem;
+      opacity: 0;
+      transform: translateX(-12px);
+      transition: opacity 0.4s ease var(--td, 0s), transform 0.4s ease var(--td, 0s);
+    }
+    .tl-item.vis { opacity: 1; transform: none; }
+
+    .tl-item::before {
+      content: '';
+      position: absolute;
+      left: -2.875rem;
+      top: 0.3rem;
+      width: 10px; height: 10px;
+      border-radius: 50%;
+      border: 2px solid var(--amber);
+      background: var(--bg);
+      transition: background 0.3s;
+    }
+    .tl-item:first-child::before { background: var(--amber); }
+
+    .tl-year {
+      font-size: 0.62rem;
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
+      color: var(--amber);
+      margin-bottom: 0.3rem;
+    }
+    .tl-event {
+      font-family: var(--sans);
+      font-size: 1.1rem;
+      font-weight: 600;
+      color: var(--text);
+      margin-bottom: 0.3rem;
+    }
+    .tl-detail {
+      font-size: 0.76rem;
+      color: var(--muted);
+      line-height: 1.7;
+      font-weight: 300;
+      max-width: 560px;
+    }
+
+    /* ── FOOTER ──────────────────────────────────────────────────── */
+    footer {
+      border-top: 1px solid var(--border);
+      max-width: 1200px;
+      margin: 0 auto;
+      padding: 2.75rem 2.5rem;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 1rem;
+    }
+
+    .ft-name {
+      font-family: var(--sans);
+      font-size: 1rem;
+      font-weight: 700;
+      color: var(--text);
+      margin-bottom: 0.2rem;
+    }
+    .ft-sub { font-size: 0.68rem; color: var(--muted); letter-spacing: 0.06em; }
+
+    .ft-links { display: flex; gap: 2rem; }
+    .ft-link {
+      color: var(--muted);
+      text-decoration: none;
+      font-size: 0.72rem;
+      letter-spacing: 0.08em;
+      display: flex;
+      align-items: center;
+      gap: 0.4rem;
+      transition: color 0.2s;
+    }
+    .ft-link:hover { color: var(--amber); }
+
+    /* ── REVEAL utility ──────────────────────────────────────────── */
+    .reveal {
+      opacity: 0;
+      transform: translateY(12px);
+      transition: opacity 0.5s ease, transform 0.5s ease;
+    }
+    .reveal.vis { opacity:1; transform:none; }
+
+    /* ── RESPONSIVE ──────────────────────────────────────────────── */
+    @media (max-width: 720px) {
+      nav { padding: 1rem 1.5rem; }
+      .nav-links { display: none; }
+      .hero-inner { grid-template-columns: 1fr; gap: 2rem; text-align: center; padding: 0 1.5rem; padding-top: 5rem; }
+      .avi-wrap { margin: 0 auto; }
+      .hero-eyebrow { justify-content: center; }
+      .hero-chips { justify-content: center; }
+      .section { padding: 5rem 1.5rem; }
+      .projects-grid { grid-template-columns: 1fr; }
+      footer { flex-direction: column; text-align: center; }
+      .ft-links { justify-content: center; }
+      .timeline { padding-left: 1.75rem; }
+    }
+  </style>
 </head>
 <body>
 
-<div class="jumbotron d-flex align-items-center bg-transparent">
-    <div class="container">
-        <div class="d-flex flex-wrap">
-            <div class="flex-column">
-                <h1>Yash Krishan Verma</h1>
-                <p>
-                    Senior Software Engineer @ <a href="https://www.equifax.com/" target="_blank" style="color: chartreuse;">Equifax</a><br>
-                    Developer of <a href="https://hushup.app" target="_blank" style="color: chartreuse;">HushUP</a><br>
-                    IIT Indore
-                </p>
-                <a href="https://stackoverflow.com/users/8259771/yash-krishan"><img src="https://stackoverflow.com/users/flair/8259771.png?theme=dark" width="208" height="58" alt="profile for Yash Krishan at Stack Overflow, Q&amp;A for professional and enthusiast programmers" title="profile for Yash Krishan at Stack Overflow, Q&amp;A for professional and enthusiast programmers"></a>           
-            </div>
-        </div>
-        <hr>
-        <div class="d-flex flex-wrap justify-content-between">
-            <div class="d-flex flex-column">
-                <div class="d-flex justify-content-start">
-                    <h2>Languages I Code</h2>
-                </div>
-                <div class="row">
-                    <div class="col-12 col-sm-6 col-md-3 mb-3">
-                        <div class="d-flex">
-                            <p class="h5"><i class="fab fa-golang mr-2"></i>Go</p>
-                        </div>
-                    </div>
-                    <div class="col-12 col-sm-6 col-md-3 mb-3">
-                        <div class="d-flex">
-                            <p class="h5"><i class="fab fa-java mr-2"></i>Java</p>
-                        </div>
-                    </div>
-                    <div class="col-12 col-sm-6 col-md-3 mb-3">
-                        <div class="d-flex">
-                            <p class="h5"><i class="fab fa-js mr-2"></i>TypeScript</p>
-                        </div>
-                    </div>
-                    <div class="col-12 col-sm-6 col-md-3 mb-3">
-                        <div class="d-flex">
-                            <p class="h5"><i class="fas fa-code mr-2"></i>C/C++</p>
-                        </div>
-                    </div>
-                    <div class="col-12 col-sm-6 col-md-3 mb-3">
-                        <div class="d-flex">
-                            <p class="h5"><i class="fab fa-python mr-2"></i>Python</p>
-                        </div>
-                    </div>
-                    <div class="col-12 col-sm-6 col-md-3 mb-3">
-                        <div class="d-flex">
-                            <p class="h5"><i class="fab fa-js-square mr-2"></i>JavaScript</p>
-                        </div>
-                    </div>
-                    <div class="col-12 col-sm-6 col-md-3 mb-3">
-                        <div class="d-flex">
-                            <p class="h5"><i class="fab fa-php mr-2"></i>PHP</p>
-                        </div>
-                    </div>
-                    <div class="col-12 col-sm-6 col-md-3 mb-3">
-                        <div class="d-flex">
-                            <p class="h5"><i class="fas fa-terminal mr-2"></i>Bash</p>
-                        </div>
-                    </div>
-                </div>
-                <div class="d-flex justify-content-start mt-4">
-                    <h2>Technologies I Work With</h2>
-                </div>
-                
-                <!-- Frameworks -->
-                <div class="mb-4">
-                    <p class="h6 font-weight-bold mb-3">Frameworks</p>
-                    <div class="row">
-                        <div class="col-12 col-sm-6 col-md-3 mb-3">
-                            <p class="h5"><i class="fas fa-leaf mr-2"></i>Spring Boot</p>
-                        </div>
-                        <div class="col-12 col-sm-6 col-md-3 mb-3">
-                            <p class="h5"><i class="fab fa-node-js mr-2"></i>Express</p>
-                        </div>
-                        <div class="col-12 col-sm-6 col-md-3 mb-3">
-                            <p class="h5"><i class="fab fa-react mr-2"></i>React.js</p>
-                        </div>
-                        <div class="col-12 col-sm-6 col-md-3 mb-3">
-                            <p class="h5"><i class="fab fa-python mr-2"></i>Django</p>
-                        </div>
-                        <div class="col-12 col-sm-6 col-md-3 mb-3">
-                            <p class="h5"><i class="fab fa-python mr-2"></i>Flask</p>
-                        </div>
-                        <div class="col-12 col-sm-6 col-md-3 mb-3">
-                            <p class="h5"><i class="fab fa-angular mr-2"></i>Angular2+</p>
-                        </div>
-                    </div>
-                </div>
-                
-                <!-- Developer Tools -->
-                <div class="mb-4">
-                    <p class="h6 font-weight-bold mb-3">Developer Tools</p>
-                    <div class="row">
-                        <div class="col-12 col-sm-6 col-md-3 mb-3">
-                            <p class="h5"><i class="fas fa-dharmachakra mr-2"></i>Kubernetes</p>
-                        </div>
-                        <div class="col-12 col-sm-6 col-md-3 mb-3">
-                            <p class="h5"><i class="fab fa-docker mr-2"></i>Docker</p>
-                        </div>
-                        <div class="col-12 col-sm-6 col-md-3 mb-3">
-                            <p class="h5"><i class="fas fa-cogs mr-2"></i>Jenkins</p>
-                        </div>
-                        <div class="col-12 col-sm-6 col-md-3 mb-3">
-                            <p class="h5"><i class="fas fa-ship mr-2"></i>Helm</p>
-                        </div>
-                        <div class="col-12 col-sm-6 col-md-3 mb-3">
-                            <p class="h5"><i class="fab fa-git-alt mr-2"></i>Git</p>
-                        </div>
-                        <div class="col-12 col-sm-6 col-md-3 mb-3">
-                            <p class="h5"><i class="fab fa-google mr-2"></i>GCP</p>
-                        </div>
-                        <div class="col-12 col-sm-6 col-md-3 mb-3">
-                            <p class="h5"><i class="fab fa-aws mr-2"></i>AWS</p>
-                        </div>
-                    </div>
-                </div>
-                
-                <!-- Databases -->
-                <div class="mb-4">
-                    <p class="h6 font-weight-bold mb-3">Databases</p>
-                    <div class="row">
-                        <div class="col-12 col-sm-6 col-md-3 mb-3">
-                            <p class="h5"><i class="fas fa-database mr-2"></i>MySQL</p>
-                        </div>
-                        <div class="col-12 col-sm-6 col-md-3 mb-3">
-                            <p class="h5"><i class="fas fa-database mr-2"></i>PostgreSQL</p>
-                        </div>
-                        <div class="col-12 col-sm-6 col-md-3 mb-3">
-                            <p class="h5"><i class="fas fa-leaf mr-2"></i>MongoDB</p>
-                        </div>
-                        <div class="col-12 col-sm-6 col-md-3 mb-3">
-                            <p class="h5"><i class="fas fa-fire mr-2"></i>Firestore</p>
-                        </div>
-                    </div>
-                </div>
-                
-                <!-- Observability -->
-                <div class="mb-4">
-                    <p class="h6 font-weight-bold mb-3">Observability</p>
-                    <div class="row">
-                        <div class="col-12 col-sm-6 col-md-3 mb-3">
-                            <p class="h5"><i class="fas fa-chart-line mr-2"></i>Grafana</p>
-                        </div>
-                        <div class="col-12 col-sm-6 col-md-3 mb-3">
-                            <p class="h5"><i class="fas fa-file-alt mr-2"></i>GCP Logging</p>
-                        </div>
-                        <div class="col-12 col-sm-6 col-md-3 mb-3">
-                            <p class="h5"><i class="fas fa-dog mr-2"></i>Datadog</p>
-                        </div>
-                        <div class="col-12 col-sm-6 col-md-3 mb-3">
-                            <p class="h5"><i class="fas fa-bell mr-2"></i>PagerDuty</p>
-                        </div>
-                    </div>
-                </div>
-            </div>
-            <div class="d-flex flex-column">
-                <div class="d-flex justify-content-start">
-                    <h2>Connect</h2>
-                </div>
-                <div class="row">
-                    <div class="col-12 col-sm-6 col-md-3 mb-3">
-                        <p class="h5"><a href="https://www.linkedin.com/in/yash-krishan-verma/" target="_blank"><i class="fab fa-linkedin mr-2"></i>LinkedIn</a></p>
-                    </div>
-                    <div class="col-12 col-sm-6 col-md-3 mb-3">
-                        <p class="h5"><a href="https://github.com/stupidly-logical" target="_blank"><i class="fab fa-github mr-2"></i>GitHub</a></p>
-                    </div>
-                    <div class="col-12 col-sm-6 col-md-3 mb-3">
-                        <p class="h5"><a href="https://stackoverflow.com/users/8259771/yash-krishan" target="_blank"><i class="fab fa-stack-overflow mr-2"></i>StackOverflow</a></p>
-                    </div>
-                </div>
-            </div>
-        </div>
-        <hr>
-        <div class="d-flex flex-wrap justify-content-center">
-            <p class="h5"><a href="mailto:yash.at.tech@gmail.com"><i class="fas fa-envelope mr-2"></i>Email: </a><i>yash.at.tech@gmail.com</i></p>
-        </div>
-    </div>
-</div>
+<!-- ── NAV ───────────────────────────────────────────────────────── -->
+<nav>
+  <div class="nav-logo">~/<em>yash</em> <span style="color:var(--muted)">$</span></div>
+  <ul class="nav-links">
+    <li><a href="#skills">Stack</a></li>
+    <li><a href="#projects">Projects</a></li>
+    <li><a href="#journey">Journey</a></li>
+    <li><a href="https://github.com/stupidly-logical" target="_blank" rel="noopener">GitHub&nbsp;↗</a></li>
+  </ul>
+</nav>
 
-<!-- Optional JavaScript -->
-<!-- jQuery first, then Popper.js, then Bootstrap JS -->
-<script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
-<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
+<!-- ── HERO ──────────────────────────────────────────────────────── -->
+<section id="hero">
+  <canvas id="net-canvas"></canvas>
+
+  <div class="hero-inner">
+    <div class="avi-wrap">
+      <img src="https://avatars.githubusercontent.com/u/17554626?v=4" alt="Yash" width="155" height="155">
+      <div class="avi-dot"></div>
+    </div>
+
+    <div class="hero-text">
+      <div class="hero-eyebrow">Backend Engineer &nbsp;·&nbsp; India</div>
+      <h1 class="hero-name">Yash</h1>
+      <p class="hero-tagline"><span id="tw"></span><span class="cursor"></span></p>
+      <div class="hero-chips">
+        <span class="chip hire">Open to opportunities</span>
+        <span class="chip">10 yrs on GitHub</span>
+        <span class="chip">India · Remote</span>
+      </div>
+    </div>
+  </div>
+
+  <div class="scroll-cue">scroll</div>
+</section>
+
+<!-- ── SKILLS ─────────────────────────────────────────────────────── -->
+<section id="skills" class="section">
+  <p class="s-eyebrow">// capabilities</p>
+  <h2 class="s-title reveal">Tech <span>Stack</span></h2>
+
+  <div class="skills-grid">
+    <div class="skill-group">
+      <div class="sg-name">Core Languages</div>
+      <div class="sg-tags">
+        <span class="tag">Java 21</span>
+        <span class="tag">Go</span>
+        <span class="tag">Python</span>
+        <span class="tag">C</span>
+        <span class="tag">C++</span>
+        <span class="tag">JavaScript</span>
+      </div>
+    </div>
+    <div class="skill-group">
+      <div class="sg-name">Distributed Systems</div>
+      <div class="sg-tags">
+        <span class="tag">Apache Kafka</span>
+        <span class="tag">Avro</span>
+        <span class="tag">Outbox Pattern</span>
+        <span class="tag">Saga Orchestration</span>
+        <span class="tag">Event Sourcing</span>
+      </div>
+    </div>
+    <div class="skill-group">
+      <div class="sg-name">Frameworks & Data</div>
+      <div class="sg-tags">
+        <span class="tag">Spring Boot 3</span>
+        <span class="tag">Flask</span>
+        <span class="tag">Node.js</span>
+        <span class="tag">PostgreSQL</span>
+        <span class="tag">OAuth2</span>
+        <span class="tag">Flyway</span>
+      </div>
+    </div>
+    <div class="skill-group">
+      <div class="sg-name">Infrastructure</div>
+      <div class="sg-tags">
+        <span class="tag">Docker</span>
+        <span class="tag">Kubernetes</span>
+        <span class="tag">GitHub Actions</span>
+        <span class="tag">Prometheus</span>
+        <span class="tag">Grafana</span>
+        <span class="tag">Helm</span>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ── PROJECTS ───────────────────────────────────────────────────── -->
+<section id="projects" class="section" style="padding-top:0">
+  <p class="s-eyebrow">// selected work</p>
+  <h2 class="s-title reveal">Featured <span>Projects</span></h2>
+
+  <div class="projects-grid">
+
+    <a class="proj-card" href="https://github.com/stupidly-logical/payment-outbox" target="_blank" rel="noopener">
+      <div class="proj-meta"><span class="dot"></span>Active · 2026</div>
+      <div class="proj-name">Payment Outbox</div>
+      <div class="proj-desc">Distributed payment processor using the Transactional Outbox Pattern. Exactly-once event delivery across microservices — no distributed transactions needed.</div>
+      <div class="proj-tags">
+        <span class="ptag">Java 21</span><span class="ptag">Spring Boot 3</span><span class="ptag">Kafka</span><span class="ptag">Avro</span><span class="ptag">PostgreSQL</span><span class="ptag">Docker</span>
+      </div>
+      <div class="proj-cta">View on GitHub <span>→</span></div>
+    </a>
+
+    <a class="proj-card" href="https://github.com/stupidly-logical/springboot-oauth2" target="_blank" rel="noopener">
+      <div class="proj-meta"><span class="dot"></span>2025</div>
+      <div class="proj-name">Spring Boot OAuth2</div>
+      <div class="proj-desc">Production-grade OAuth2 authentication with Spring Security — token lifecycle, scope management, and secure API access patterns done right.</div>
+      <div class="proj-tags">
+        <span class="ptag">Java</span><span class="ptag">Spring Security</span><span class="ptag">OAuth2</span><span class="ptag">JWT</span>
+      </div>
+      <div class="proj-cta">View on GitHub <span>→</span></div>
+    </a>
+
+    <a class="proj-card" href="https://github.com/stupidly-logical/spring-boot-k8s" target="_blank" rel="noopener">
+      <div class="proj-meta"><span class="dot old"></span>2022</div>
+      <div class="proj-name">Spring Boot on K8s</div>
+      <div class="proj-desc">End-to-end Kubernetes deployment for Spring Boot microservices. Helm charts, readiness probes, config management — production-ready from day one.</div>
+      <div class="proj-tags">
+        <span class="ptag">Spring Boot</span><span class="ptag">Kubernetes</span><span class="ptag">Helm</span><span class="ptag">Docker</span>
+      </div>
+      <div class="proj-cta">View on GitHub <span>→</span></div>
+    </a>
+
+    <a class="proj-card" href="https://github.com/stupidly-logical/rfc-c" target="_blank" rel="noopener">
+      <div class="proj-meta"><span class="dot old"></span>2023</div>
+      <div class="proj-name">RFC Implementations in C</div>
+      <div class="proj-desc">Network protocols implemented from the spec, in C. The kind of work that makes every abstraction above it make sense — going all the way down.</div>
+      <div class="proj-tags">
+        <span class="ptag">C</span><span class="ptag">Networking</span><span class="ptag">Protocols</span><span class="ptag">RFC</span>
+      </div>
+      <div class="proj-cta">View on GitHub <span>→</span></div>
+    </a>
+
+    <a class="proj-card" href="https://github.com/stupidly-logical/flask-rest-upload" target="_blank" rel="noopener">
+      <div class="proj-meta"><span class="dot old"></span>2019</div>
+      <div class="proj-name">Resumable Upload API</div>
+      <div class="proj-desc">REST API supporting pause, resume, and stop for file uploads — an early hint at fault-tolerant systems thinking, long before it became a theme.</div>
+      <div class="proj-tags">
+        <span class="ptag">Python</span><span class="ptag">Flask</span><span class="ptag">REST</span><span class="ptag">Docker</span>
+      </div>
+      <div class="proj-cta">View on GitHub <span>→</span></div>
+    </a>
+
+    <a class="proj-card" href="https://github.com/stupidly-logical/Permioid" target="_blank" rel="noopener">
+      <div class="proj-meta"><span class="dot old"></span>2019</div>
+      <div class="proj-name">Permioid</div>
+      <div class="proj-desc">Android library for seamless runtime permission management. A clean API over Android's verbose permission model — written when libraries meant writing real Java.</div>
+      <div class="proj-tags">
+        <span class="ptag">Java</span><span class="ptag">Android</span><span class="ptag">Library</span>
+      </div>
+      <div class="proj-cta">View on GitHub <span>→</span></div>
+    </a>
+
+  </div>
+</section>
+
+<!-- ── JOURNEY ────────────────────────────────────────────────────── -->
+<section id="journey" class="section" style="padding-top:0">
+  <p class="s-eyebrow">// git log --all --oneline</p>
+  <h2 class="s-title reveal">The <span>Journey</span></h2>
+
+  <div class="timeline">
+    <div class="tl-item">
+      <div class="tl-year">2024 — Present</div>
+      <div class="tl-event">Distributed Systems at Scale</div>
+      <div class="tl-detail">Event-driven architecture, Kafka, the Outbox Pattern, saga orchestration. Building payment systems that stay correct when everything around them fails.</div>
+    </div>
+    <div class="tl-item">
+      <div class="tl-year">2021 — 2023</div>
+      <div class="tl-event">Cloud-Native & Infrastructure</div>
+      <div class="tl-detail">Kubernetes, Helm, Spring Boot on K8s. Shifted focus from writing code to thinking about how it runs — resilience, observability, zero-downtime deploys.</div>
+    </div>
+    <div class="tl-item">
+      <div class="tl-year">2019 — 2021</div>
+      <div class="tl-event">Backend APIs, Polyglot Phase</div>
+      <div class="tl-detail">Go REST APIs, Python/Flask microservices, Node.js. Learning that every language is a different way of thinking about the same problems.</div>
+    </div>
+    <div class="tl-item">
+      <div class="tl-year">2016 — 2019</div>
+      <div class="tl-event">Android & Open Source</div>
+      <div class="tl-detail">Shipped Android libraries, contributed to open source, studied real production codebases. Learning to read code before writing it.</div>
+    </div>
+    <div class="tl-item">
+      <div class="tl-year">Feb 2016</div>
+      <div class="tl-event">First Commit</div>
+      <div class="tl-detail">Hello World. Home automation with Arduino and Python. A curious mind with a compiler and too much time — the only good kind of start.</div>
+    </div>
+  </div>
+</section>
+
+<!-- ── FOOTER ─────────────────────────────────────────────────────── -->
+<footer>
+  <div>
+    <div class="ft-name">Yash</div>
+    <div class="ft-sub">Backend Engineer · India · Available for Work</div>
+  </div>
+  <div class="ft-links">
+    <a class="ft-link" href="https://github.com/stupidly-logical" target="_blank" rel="noopener">
+      <svg width="13" height="13" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.374 0 0 5.373 0 12c0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0112 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576C20.566 21.797 24 17.3 24 12c0-6.627-5.373-12-12-12z"/></svg>
+      GitHub
+    </a>
+    <a class="ft-link" href="https://stupidly-logical.github.io/" target="_blank" rel="noopener">Portfolio ↗</a>
+  </div>
+</footer>
+
+<script>
+// ── CANVAS — distributed network with data packets ─────────────────
+(function () {
+  const canvas = document.getElementById('net-canvas');
+  const ctx    = canvas.getContext('2d');
+  const A      = 'rgba(245,158,11,'; // amber prefix
+  const N      = 55;   // node count
+  const D      = 155;  // connection distance
+  let nodes = [], packets = [], raf, frame = 0;
+
+  function resize() {
+    canvas.width  = window.innerWidth;
+    canvas.height = window.innerHeight;
+  }
+
+  class Node {
+    constructor(first) {
+      this.x  = Math.random() * canvas.width;
+      this.y  = first ? Math.random() * canvas.height : Math.random() * canvas.height;
+      this.vx = (Math.random() - 0.5) * 0.35;
+      this.vy = (Math.random() - 0.5) * 0.35;
+      this.r  = Math.random() * 1.4 + 0.5;
+      this.ph = Math.random() * Math.PI * 2;
+      this.hot= Math.random() > 0.72;
+    }
+    tick() {
+      this.x  += this.vx;
+      this.y  += this.vy;
+      this.ph += 0.016;
+      if (this.x < -30) this.x = canvas.width  + 30;
+      if (this.x > canvas.width  + 30) this.x = -30;
+      if (this.y < -30) this.y = canvas.height + 30;
+      if (this.y > canvas.height + 30) this.y = -30;
+    }
+    draw() {
+      const a = this.hot ? 0.65 + Math.sin(this.ph) * 0.35 : 0.2;
+      ctx.beginPath();
+      ctx.arc(this.x, this.y, this.r, 0, 6.283);
+      ctx.fillStyle = A + a + ')';
+      ctx.fill();
+      if (this.hot) {
+        ctx.beginPath();
+        ctx.arc(this.x, this.y, this.r * 5, 0, 6.283);
+        ctx.fillStyle = A + (0.05 + 0.04 * Math.sin(this.ph)) + ')';
+        ctx.fill();
+      }
+    }
+  }
+
+  class Packet {
+    constructor(a, b) {
+      this.a = a; this.b = b;
+      this.t = 0;
+      this.sp= 0.007 + Math.random() * 0.009;
+    }
+    tick() { this.t += this.sp; return this.t >= 1; }
+    draw() {
+      const x = this.a.x + (this.b.x - this.a.x) * this.t;
+      const y = this.a.y + (this.b.y - this.a.y) * this.t;
+      ctx.beginPath(); ctx.arc(x, y, 2.5, 0, 6.283);
+      ctx.fillStyle = A + '0.95)'; ctx.fill();
+      ctx.beginPath(); ctx.arc(x, y, 6, 0, 6.283);
+      ctx.fillStyle = A + '0.18)'; ctx.fill();
+    }
+  }
+
+  function spawnPacket() {
+    const a = nodes[Math.floor(Math.random() * nodes.length)];
+    const nb = nodes.filter(n => {
+      if (n === a) return false;
+      const dx = n.x-a.x, dy = n.y-a.y;
+      return Math.sqrt(dx*dx+dy*dy) < D;
+    });
+    if (nb.length) packets.push(new Packet(a, nb[Math.floor(Math.random()*nb.length)]));
+  }
+
+  function draw() {
+    raf = requestAnimationFrame(draw);
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+    // edges
+    for (let i = 0; i < nodes.length; i++) {
+      for (let j = i+1; j < nodes.length; j++) {
+        const dx = nodes[i].x-nodes[j].x, dy = nodes[i].y-nodes[j].y;
+        const d  = Math.sqrt(dx*dx+dy*dy);
+        if (d < D) {
+          ctx.beginPath();
+          ctx.moveTo(nodes[i].x, nodes[i].y);
+          ctx.lineTo(nodes[j].x, nodes[j].y);
+          ctx.strokeStyle = A + ((1-d/D)*0.18) + ')';
+          ctx.lineWidth = 0.5;
+          ctx.stroke();
+        }
+      }
+    }
+
+    nodes.forEach(n => { n.tick(); n.draw(); });
+
+    frame++;
+    if (frame % 45 === 0) spawnPacket();
+    packets = packets.filter(p => { p.draw(); return !p.tick(); });
+  }
+
+  resize();
+  nodes = Array.from({length: N}, (_, i) => new Node(true));
+  draw();
+
+  // pause when hero scrolled away
+  const heroEl = document.getElementById('hero');
+  new IntersectionObserver(([e]) => {
+    if (e.isIntersecting) { if (!raf) draw(); }
+    else { cancelAnimationFrame(raf); raf = null; }
+  }).observe(heroEl);
+
+  window.addEventListener('resize', () => {
+    resize();
+    nodes.forEach(n => { n.x = Math.random()*canvas.width; n.y = Math.random()*canvas.height; });
+  });
+})();
+
+// ── TYPEWRITER ─────────────────────────────────────────────────────
+(function () {
+  const phrases = [
+    'Building distributed systems.',
+    'Event-driven architecture.',
+    'Making payments reliable.',
+    'Backend engineer. India.',
+    '10 years of shipping code.',
+    'Kafka. Postgres. Spring Boot.',
+  ];
+  let pi = 0, ci = 0, del = false;
+  const el = document.getElementById('tw');
+
+  function step() {
+    const s = phrases[pi];
+    if (del) {
+      el.textContent = s.slice(0, --ci);
+      if (ci === 0) { del = false; pi = (pi+1) % phrases.length; setTimeout(step, 380); }
+      else setTimeout(step, 38);
+    } else {
+      el.textContent = s.slice(0, ++ci);
+      if (ci === s.length) { del = true; setTimeout(step, 2400); }
+      else setTimeout(step, 68);
+    }
+  }
+  setTimeout(step, 900);
+})();
+
+// ── SCROLL REVEAL ──────────────────────────────────────────────────
+(function () {
+  const obs = new IntersectionObserver(entries => {
+    entries.forEach(e => {
+      if (e.isIntersecting) { e.target.classList.add('vis'); obs.unobserve(e.target); }
+    });
+  }, { threshold: 0.12 });
+
+  // generic reveals
+  document.querySelectorAll('.reveal').forEach(el => obs.observe(el));
+
+  // staggered groups
+  function stagger(selector, prop, step) {
+    document.querySelectorAll(selector).forEach((el, i) => {
+      el.style.setProperty(prop, (i * step) + 's');
+      obs.observe(el);
+    });
+  }
+
+  stagger('.skill-group', '--sd', 0.09);
+  stagger('.proj-card',   '--pd', 0.07);
+  stagger('.tl-item',     '--td', 0.1);
+})();
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- Complete redesign of `index.html` with a dark terminal aesthetic using JetBrains Mono + Syne fonts, animated canvas network background, typewriter hero, skills grid, project cards, and journey timeline
- Three-way light/dark/system theme toggle in the nav with `prefers-color-scheme` detection, `localStorage` persistence, and an anti-flash inline script to prevent flicker on load

## Test plan

- [ ] Page loads without theme flicker (anti-flash script fires before render)
- [ ] Dark mode toggle applies dark palette
- [ ] Light mode toggle applies light palette
- [ ] System mode follows OS preference and updates live when OS theme changes
- [ ] Selected theme persists across page reloads
- [ ] Responsive layout works on mobile (nav links hidden, toggle visible)
- [ ] Canvas animation, typewriter, and scroll reveal all function correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)