### PR TITLE
Add bio description to hero section

### DIFF
--- a/index.html
+++ b/index.html
@@ -218,6 +218,20 @@
     /* Hero text */
     .hero-text {}
 
+    .hero-desc {
+      margin-top: 1.6rem;
+      font-size: 0.82rem;
+      color: var(--dim);
+      font-weight: 300;
+      line-height: 1.85;
+      max-width: 520px;
+    }
+    .hero-desc a {
+      color: var(--amber);
+      text-decoration: none;
+    }
+    .hero-desc a:hover { text-decoration: underline; }
+
     .hero-eyebrow {
       display: flex;
       align-items: center;
@@ -671,6 +685,15 @@
         <span class="chip">10 yrs on GitHub</span>
         <span class="chip">India · Remote</span>
       </div>
+      <p class="hero-desc">
+        Backend software engineer with 5.5+ years building scalable, high-performance systems.
+        Currently at <a href="https://seekout.com/" target="_blank">SeekOut</a>, where I re-architected
+        an analytics platform from 10–20s query latency down to &lt;100ms across 40K+ pipelines.
+        Previously at Equifax, I designed a Go + gRPC orchestrator handling 50K+ requests/minute
+        and a Java SDK adopted by 8 teams processing 1M+ events daily.
+        B.Tech Computer Science, IIT Indore.
+        Also building <a href="https://hushup.app" target="_blank">HushUP</a> — 100K monthly active users and counting.
+      </p>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary

- Adds a bio paragraph to the hero section drawn from resume data
- Covers current role at SeekOut with the 100x query performance achievement, prior Equifax work (50K+ req/min gRPC API, 1M+ events/day Java SDK), IIT Indore education, and HushUP (100K MAU)

## Test plan

- [ ] Description renders correctly below the hero chips
- [ ] Links to SeekOut and HushUP open in a new tab
- [ ] Layout holds on mobile (centered, readable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)